### PR TITLE
Respect <CR> instead of treating command as single line

### DIFF
--- a/lua/term-edit/config.lua
+++ b/lua/term-edit/config.lua
@@ -5,10 +5,22 @@ local M = {
   },
 }
 
+---@class TermEditOpts
+---@field prompt_start string
+---@field debug? boolean
+---@field key_queue_time? integer
+
 ---set options for term-edit
----@param opts { debug?: boolean, key_queue_time?: integer }
+---@param opts TermEditOpts
 function M.setup(opts)
-  opts = opts or {}
+  if not opts or not opts.prompt_start then
+    vim.notify([[
+prompt_start is a mandatory argument to setup!
+Please provide it with a lua pattern that would match the end of the shell prompt.
+Say if your shell prompt is `user@Host ~ $ ` then do:
+`require('term-edit').setup { prompt_start = ' %$ ' }`
+    ]], vim.log.levels.WARN)
+  end
   M.opts = vim.tbl_deep_extend('force', M.opts, opts)
 end
 

--- a/lua/term-edit/config.lua
+++ b/lua/term-edit/config.lua
@@ -1,4 +1,5 @@
 local M = {
+  ---@type TermEditOpts
   opts = {
     debug = false,
     feedkeys_delay = 3,
@@ -7,8 +8,8 @@ local M = {
 
 ---@class TermEditOpts
 ---@field prompt_start string
----@field debug? boolean
----@field key_queue_time? integer
+---@field debug boolean
+---@field key_queue_time integer
 
 ---set options for term-edit
 ---@param opts TermEditOpts

--- a/lua/term-edit/coord.lua
+++ b/lua/term-edit/coord.lua
@@ -1,11 +1,63 @@
+local config = require 'term-edit.config'
 local M = {}
 
 ---@class Coord
 ---@field col integer
 ---@field line integer
 
+local function get_winwidth()
+  return vim.fn.winwidth(0) - vim.fn.wincol() + vim.fn.col '.'
+end
+
+local function find_line_start()
+  local lnum = vim.fn.line '.'
+  local winwidth = get_winwidth()
+  local line = vim.fn.getline(lnum) --[[@as string]]
+  while true do
+    local _, start_col = string.find(line, config.opts.prompt_start)
+    if start_col then
+      -- found prompt_start
+      return { line = lnum, col = start_col + 1 }
+    end
+
+    lnum = lnum - 1
+    if lnum < 1 then
+      vim.notify('Can not find prompt_start: ' .. config.opts.prompt_start)
+    end
+
+    line = vim.fn.getline(lnum) --[[@as string]]
+    if #line < winwidth then
+      -- current lnum end with <CR>
+      -- last lnum is line start
+      return { line = lnum + 1, col = 1 }
+    end
+  end
+end
+
+local function find_line_end()
+  local winwidth = get_winwidth()
+  local lnum = vim.fn.line '.'
+  local line = vim.fn.getline(lnum) --[[@as string]]
+  while #line == winwidth do
+    -- lnum don't end with <CR>
+    lnum = lnum + 1
+    line = vim.fn.getline(lnum) --[[@as string]]
+  end
+  return { line = lnum, col = #line }
+end
+
+---get coord with expr, '.' is cursor, '0' is start of the line
+---and '$' is end of the line
+---@param expr string
+---@return Coord
 function M.get_coord(expr)
-  return { line = vim.fn.line(expr), col = vim.fn.col(expr) }
+  if expr == '0' then
+    return find_line_start()
+  elseif expr == '$' then
+    return find_line_end()
+  else
+    return { line = vim.fn.line(expr), col = vim.fn.col(expr) }
+  end
 end
 
 function M.equals(c1, c2)

--- a/lua/term-edit/init.lua
+++ b/lua/term-edit/init.lua
@@ -126,6 +126,8 @@ local function maybe_enable()
   end
 end
 
+---setup term-edit
+---@param opts TermEditOpts
 function M.setup(opts)
   config.setup(opts)
 

--- a/lua/term-edit/init.lua
+++ b/lua/term-edit/init.lua
@@ -4,11 +4,9 @@ local coord = require 'term-edit.coord'
 local config = require 'term-edit.config'
 local async = require 'term-edit.async'
 local delete = require 'term-edit.delete'
-local M = {
-  setup = config.setup,
-}
+local M = {}
 
----@class AutocmdOpts
+---@class AutoCmdOpts
 ---@field pattern? string[]|string
 ---@field buffer? integer
 ---@field desc? string
@@ -19,7 +17,7 @@ local M = {
 
 ---create autocmds
 ---@param name string
----@param autocmds { event: string[]|string, opts: AutocmdOpts }[]
+---@param autocmds { event: string[]|string, opts: AutoCmdOpts }[]
 local function create_autocmds(name, autocmds)
   local id = vim.api.nvim_create_augroup(name, {})
   for _, autocmd in ipairs(autocmds) do
@@ -128,22 +126,26 @@ local function maybe_enable()
   end
 end
 
-create_autocmds('term_enter_map_insert', {
-  {
-    event = 'OptionSet',
-    opts = {
-      pattern = 'buftype',
-      callback = maybe_enable,
-    },
-  },
-  { -- tolerate lazy loading
-    event = 'BufEnter',
-    opts = {
-      callback = maybe_enable,
-    },
-  },
-})
+function M.setup(opts)
+  config.setup(opts)
 
-maybe_enable() -- tolerate lazy loading
+  create_autocmds('term_enter_map_insert', {
+    {
+      event = 'OptionSet',
+      opts = {
+        pattern = 'buftype',
+        callback = maybe_enable,
+      },
+    },
+    { -- tolerate lazy loading
+      event = 'BufEnter',
+      opts = {
+        callback = maybe_enable,
+      },
+    },
+  })
+
+  maybe_enable() -- tolerate lazy loading
+end
 
 return M

--- a/lua/term-edit/init.lua
+++ b/lua/term-edit/init.lua
@@ -75,10 +75,10 @@ local function maybe_enable()
       })
     end)
     map('A', function()
-      insert.enter_insert { line = vim.fn.line '$' + 1, col = 1 }
+      insert.enter_insert(coord.get_coord '$')
     end)
     map('I', function()
-      insert.enter_insert { line = 0, col = 1 }
+      insert.enter_insert(coord.get_coord '0')
     end)
 
     -- delete
@@ -102,8 +102,31 @@ local function maybe_enable()
         post_nav = 1,
       })
     end, { expr = true })
-    remap('dd', '0d$')
-    remap('D', 'd$')
+    map('dd', function()
+      local line_end = coord.get_coord '$'
+      delete.delete_range(
+        coord.get_coord '0',
+        { line = line_end.line, col = line_end.col + 1 },
+        {
+          callback = function()
+            async.feedkeys '<C-\\><C-n>'
+          end,
+          post_nav = 1,
+        }
+      )
+    end)
+    map('D', function()
+      local line_end = coord.get_coord '$'
+      delete.delete_range(
+        coord.get_coord '.',
+        { line = line_end.line, col = line_end.col + 1 },
+        {
+          callback = function()
+            async.feedkeys '<C-\\><C-n>'
+          end,
+        }
+      )
+    end)
     remap('x', 'dl')
 
     -- change
@@ -117,12 +140,20 @@ local function maybe_enable()
     omap('c', function()
       delete.delete_range(coord.get_coord "'[", coord.get_coord "']")
     end, { expr = true })
-    remap('cc', '0c$')
+    map('cc', function()
+      delete.delete_range(coord.get_coord '0', coord.get_coord '$')
+    end)
     remap('cw', 'ce')
     remap('cW', 'cE')
-    remap('C', 'c$')
+    map('C', function()
+      delete.delete_range(coord.get_coord '.', coord.get_coord '$', {
+        callback = function()
+          async.feedkeys '<C-\\><C-n>'
+        end,
+      })
+    end)
     remap('s', 'cl')
-    remap('S', '0c$')
+    remap('S', 'cc')
   end
 end
 


### PR DESCRIPTION
closes #16
- autocmd on setup instead of load
- added prompt_start opt and made it mandatory
- respecting cr for A, I, dd, D, cc, C & S
