### PR TITLE
Remove post nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ local default_opts = {
 - This plugin might feed more \<Left\>, \<Right\> and \<BS\> to the shell than necessary. This can happen when it is instructed to go somewhere it can't reach or delete something not a part of the command. This may make your terminal beep if you have audio bell enabled.
 - The above limitation is worse in powershell and zsh, as for them, \<Right\> is set as confirm completion. As a result, if the cursor is somewhere after the end of the command, completion will be triggered.
 - Issue #29: Sometimes there appears to be dangling spaces after the end of the command, this is an upstream bug/limitation.
+- Some shells react especially slowly, e.g. powershell. Increase feedkeys_delay to 1000 before opening an issue.
 
 ## 💻 Contribution
 All PRs are welcome.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ local default_opts = {
 ## 🚫 Limitations
 - This plugin assumes there are no \<Tab\> though it might tolerate it.
 - This plugin might feed more \<Left\>, \<Right\> and \<BS\> to the shell than necessary. This can happen when it is instructed to go somewhere it can't reach or delete something not a part of the command. This may make your terminal beep if you have audio bell enabled.
+- The above limitation is worse in powershell and zsh, as for them, \<Right\> is set as confirm completion. As a result, if the cursor is somewhere after the end of the command, completion will be triggered.
+- Issue #29: Sometimes there appears to be dangling spaces after the end of the command, this is an upstream bug/limitation.
 
 ## 💻 Contribution
 All PRs are welcome.

--- a/doc/term-edit.nvim.txt
+++ b/doc/term-edit.nvim.txt
@@ -186,4 +186,11 @@ necessary. This can happen when it is instructed to go somewhere it can't
 reach or delete something not a part of the command. This may make your
 terminal beep if you have audio bell enabled.
 
+The above limitation is worse in powershell and zsh, as for them, \<Right\> is
+set as confirm completion. As a result, if the cursor is somewhere after the
+end of the command, completion will be triggered.
+
+Issue #29: Sometimes there appears to be dangling spaces after the end of the
+command, this is an upstream bug/limitation.
+
 vim:tw=78:ts=2:sw=2:et:ft=help:norl:

--- a/lua/term-edit/async.lua
+++ b/lua/term-edit/async.lua
@@ -27,7 +27,11 @@ local function register_callback(callback, defer_more)
     local event_loop_elapsed = 0
     local function schedule_callback()
       if os.clock() > start_time + 1 then
-        vim.notify('feedkeys callbacks leak', vim.log.levels.ERROR)
+        vim.notify(
+          'feedkeys callbacks leak' .. vim.inspect(M.callbacks),
+          vim.log.levels.ERROR
+        )
+        M.callbacks = {}
       end
       if event_loop_elapsed < config.opts.feedkeys_delay then
         event_loop_elapsed = event_loop_elapsed + 1

--- a/lua/term-edit/async.lua
+++ b/lua/term-edit/async.lua
@@ -26,7 +26,7 @@ local function register_callback(callback, defer_more)
     local start_time = os.clock()
     local event_loop_elapsed = 0
     local function schedule_callback()
-      if os.clock() > start_time + 1 then
+      if os.clock() > start_time + 10 then
         vim.notify(
           'feedkeys callbacks leak' .. vim.inspect(M.callbacks),
           vim.log.levels.ERROR

--- a/lua/term-edit/async.lua
+++ b/lua/term-edit/async.lua
@@ -51,12 +51,13 @@ end
 ---Assume start in terminal mode, will execute callback in terminal mode
 ---@param keys string
 ---@param callback function? called after the keys are fed
----@param opts? { moves?: boolean }
+---@param opts? { moves?: boolean, start_normal: boolean, callback_normal: boolean }
 function M.feedkeys(keys, callback, opts)
+  opts = opts or {}
   if callback then
     local old
     register_callback(callback, function()
-      if not opts then
+      if not opts.moves then
         return false
       end
 
@@ -65,14 +66,16 @@ function M.feedkeys(keys, callback, opts)
       old = current
 
       -- wait till it doesn't move if the keys moves
-      return opts.moves and moved
+      return moved
     end)
-    keys = keys
-      .. '<C-\\><C-n>' -- exit terminal mode
-      .. '<cmd>' -- enter command mode
-      .. 'startinsert | ' -- get back to terminal mode
-      .. call_callback()
-      .. '<CR>'
+    if not opts.start_normal then
+      keys = keys .. '<C-\\><C-n>' -- exit terminal mode
+    end
+    keys = keys .. '<cmd>' -- enter command mode
+    if not opts.callback_normal then
+      keys = keys .. 'startinsert | ' -- get back to terminal mode
+    end
+    keys = keys .. call_callback() .. '<CR>'
   end
   vim.api.nvim_input(keys)
 end

--- a/lua/term-edit/insert.lua
+++ b/lua/term-edit/insert.lua
@@ -17,22 +17,11 @@ function M.move_keys(len)
 end
 
 ---Enter insert mode and place cursor at target
----@param opts? { callback?: function, post_nav?: integer }
-function M.insert_at(target, opts)
-  opts = opts or {}
+---@param callback? function
+function M.insert_at(target, callback)
   utils.debug_print('enter_insert: target: ', utils.inspect(target))
   async.vim_cmd('startinsert', function()
-    navigate.navigate_with(target, M.move_keys, function()
-      if opts.post_nav then
-        async.feedkeys(
-          M.move_keys(opts.post_nav),
-          opts.callback,
-          { moves = true }
-        )
-      elseif opts.callback then
-        opts.callback()
-      end
-    end)
+    navigate.navigate_with(target, M.move_keys, callback)
   end)
 end
 

--- a/lua/term-edit/map/change_map.lua
+++ b/lua/term-edit/map/change_map.lua
@@ -22,11 +22,7 @@ function M.enable()
   m.remap('cw', 'ce')
   m.remap('cW', 'cE')
   m.map('C', function()
-    delete.delete_range(coord.get_coord '.', coord.get_coord '$', {
-      callback = function()
-        async.quit_insert()
-      end,
-    })
+    delete.delete_range(coord.get_coord '.', coord.get_coord '$')
   end)
   m.remap('s', 'cl')
   m.remap('S', 'cc')

--- a/lua/term-edit/map/delete_map.lua
+++ b/lua/term-edit/map/delete_map.lua
@@ -2,44 +2,43 @@ local m = require 'term-edit.map.m'
 local coord = require 'term-edit.coord'
 local async = require 'term-edit.async'
 local delete = require 'term-edit.delete'
+local navigate_normal = require 'term-edit.navigate_normal'
 
 local M = {}
+
+local function adjust_cursor(start)
+  return function()
+    navigate_normal.navigate_to(start)
+  end
+end
 
 function M.enable()
   m.map('d', function()
     local start = coord.get_coord 'v'
     local end_ = coord.get_coord '.'
     async.feedkeys('<Esc>', function()
-      delete.delete_range(start, end_, {
-        callback = function()
-          async.quit_insert()
-        end,
-        post_nav = 1,
-      })
+      delete.delete_range(start, end_, function()
+        async.quit_insert(adjust_cursor(start))
+      end)
     end)
   end, { mode = 'x' })
   m.omap('d', function()
-    delete.delete_range(coord.get_coord "'[", coord.get_coord "']", {
-      callback = function()
-        async.quit_insert()
-      end,
-      post_nav = 1,
-    })
+    local start = coord.get_coord "'["
+    delete.delete_range(start, coord.get_coord "']", function()
+      async.quit_insert(adjust_cursor(start))
+    end)
   end)
   m.map('dd', function()
-    delete.delete_range(coord.get_coord '0', coord.get_coord '$+', {
-      callback = function()
-        async.quit_insert()
-      end,
-      post_nav = 1,
-    })
+    local start = coord.get_coord '0'
+    delete.delete_range(start, coord.get_coord '$+', function()
+      async.quit_insert(adjust_cursor(start))
+    end)
   end)
   m.map('D', function()
-    delete.delete_range(coord.get_coord '.', coord.get_coord '$+', {
-      callback = function()
-        async.quit_insert()
-      end,
-    })
+    local start = coord.get_coord '.'
+    delete.delete_range(start, coord.get_coord '$+', function()
+      async.quit_insert(adjust_cursor(start))
+    end)
   end)
   m.remap('x', 'dl')
   m.remap('x', 'd', { mode = 'x' })

--- a/lua/term-edit/map/insert_map.lua
+++ b/lua/term-edit/map/insert_map.lua
@@ -13,9 +13,7 @@ function M.enable()
     insert.insert_at(coord.get_coord '.')
   end)
   m.map('a', function()
-    insert.insert_at(coord.get_coord '.', {
-      post_nav = 1,
-    })
+    insert.insert_at(coord.add(coord.get_coord '.', { col = 1 }))
   end)
   m.map('A', function()
     insert.insert_at(coord.get_coord '$+')

--- a/lua/term-edit/map/paste_map.lua
+++ b/lua/term-edit/map/paste_map.lua
@@ -13,9 +13,9 @@ function M.enable()
     for p in ('pP'):gmatch '.' do
       -- normal mode
       m.map('"' .. r .. p, function()
-        insert.insert_at(coord.get_coord '.', {
-          post_nav = p == 'p' and 1 or 0,
-          callback = function()
+        insert.insert_at(
+          coord.add(coord.get_coord '.', { col = p == 'p' and 1 or 0 }),
+          function()
             async.quit_insert(function()
               async.put(r)
               async.schedule(function()
@@ -24,8 +24,8 @@ function M.enable()
                 end)
               end, 5)
             end)
-          end,
-        })
+          end
+        )
       end)
 
       -- virtual mode
@@ -36,24 +36,22 @@ function M.enable()
         local content = vim.fn.getreg(r, nil, true)
         local regtype = vim.fn.getregtype(r)
         async.feedkeys('<Esc>', function()
-          delete.delete_range(start, end_, {
-            callback = function()
-              async.quit_insert(function()
-                vim.api.nvim_put(
-                  ---@diagnostic disable-next-line: param-type-mismatch
-                  content,
-                  regtype,
-                  false,
-                  false
-                )
-                async.schedule(function()
-                  async.vim_cmd('startinsert', function()
-                    async.schedule(async.quit_insert, 5)
-                  end)
-                end, 5)
-              end)
-            end,
-          })
+          delete.delete_range(start, end_, function()
+            async.quit_insert(function()
+              vim.api.nvim_put(
+                ---@diagnostic disable-next-line: param-type-mismatch
+                content,
+                regtype,
+                false,
+                false
+              )
+              async.schedule(function()
+                async.vim_cmd('startinsert', function()
+                  async.schedule(async.quit_insert, 5)
+                end)
+              end, 5)
+            end)
+          end)
         end)
       end, { mode = 'x' })
     end

--- a/lua/term-edit/map/replace_map.lua
+++ b/lua/term-edit/map/replace_map.lua
@@ -9,15 +9,12 @@ function M.enable()
     local cursor = coord.get_coord '.'
     local replacement = vim.fn.nr2char(vim.fn.getchar())
     async.schedule(function()
-      insert.insert_at(cursor, {
-        callback = function()
-          if replacement == '<' then
-            replacement = '<lt>'
-          end
-          async.feedkeys('<BS>' .. replacement, async.quit_insert)
-        end,
-        post_nav = 1,
-      })
+      insert.insert_at(coord.add(cursor, { col = 1 }), function()
+        if replacement == '<' then
+          replacement = '<lt>'
+        end
+        async.feedkeys('<BS>' .. replacement, async.quit_insert)
+      end)
     end)
   end)
 end

--- a/lua/term-edit/navigate_normal.lua
+++ b/lua/term-edit/navigate_normal.lua
@@ -5,22 +5,28 @@ local M = {}
 ---navigate in normal mode
 ---@param target Coord
 function M.navigate_to(target)
-  local current = coord.get_coord '.'
-  local keys = nil
-  if current.line < target.line then
-    keys = string.rep('j', target.line - current.line)
-  elseif current.line > target.line then
-    keys = string.rep('k', current.line - target.line)
-  elseif current.col < target.col then
-    keys = string.rep('l', target.col - current.col)
-  elseif current.col > target.col then
-    keys = string.rep('h', current.col - target.col)
+  local function n(old)
+    local current = coord.get_coord '.'
+    if coord.equals(current, old) then
+      return
+    end
+    local keys = nil
+    if current.line < target.line then
+      keys = string.rep('j', target.line - current.line)
+    elseif current.line > target.line then
+      keys = string.rep('k', current.line - target.line)
+    elseif current.col < target.col then
+      keys = string.rep('l', target.col - current.col)
+    elseif current.col > target.col then
+      keys = string.rep('h', current.col - target.col)
+    end
+    if keys then
+      async.feedkeys(keys, function()
+        n(current)
+      end, { moves = true, start_normal = true, callback_normal = true })
+    end
   end
-  if keys then
-    async.feedkeys(keys, function()
-      M.navigate_to(target)
-    end, { moves = true, start_normal = true, callback_normal = true })
-  end
+  n()
 end
 
 return M

--- a/lua/term-edit/navigate_normal.lua
+++ b/lua/term-edit/navigate_normal.lua
@@ -4,7 +4,7 @@ local M = {}
 
 ---navigate in normal mode
 ---@param target Coord
-function M.navigate(target)
+function M.navigate_to(target)
   local current = coord.get_coord '.'
   local keys = nil
   if current.line < target.line then
@@ -18,8 +18,8 @@ function M.navigate(target)
   end
   if keys then
     async.feedkeys(keys, function()
-      M.navigate(target)
-    end, { moves = true })
+      M.navigate_to(target)
+    end, { moves = true, start_normal = true, callback_normal = true })
   end
 end
 


### PR DESCRIPTION
Changes the way a, A & d<motion> etc adjust cursor after the operation is completed.

Not using <Right> at the end anymore and powershell and zsh aren't friendly to it.

Closes #41.
Closes #45.