### PR TITLE
Tolerate `-c :term` on startup

### DIFF
--- a/lua/term-edit/init.lua
+++ b/lua/term-edit/init.lua
@@ -56,6 +56,12 @@ function M.setup(opts)
         callback = maybe_enable,
       },
     },
+    { -- allow `nvim -c :term` as OptionSet aren't triggered during startup
+      event = 'VimEnter',
+      opts = {
+        callback = maybe_enable,
+      },
+    },
   })
 
   maybe_enable() -- tolerate lazy loading


### PR DESCRIPTION
Register `VimEnter` autocommand as `OptionSet` doesn't get triggered on startup.

closes #58 